### PR TITLE
2022 03

### DIFF
--- a/CORE/Source/uRESTDWBase.pas
+++ b/CORE/Source/uRESTDWBase.pas
@@ -9714,6 +9714,15 @@ Begin
                    TDWServerContext(ServerMethodsClass.Components[i]).ContextList.ContextByName[Pooler].OnBeforeRenderer(vBaseHeader, ContentType, vResult, RequestType);
                  End;
                End;
+
+               //uhmano -- inicio  ServerContext
+               if DWParams.ItemsString['ContentType'] <> nil then
+                   ContentType := DWParams.ItemsString['ContentType'].asString;
+
+               if DWParams.ItemsString['StatusCode'] <> nil then
+                   ErrorCode := DWParams.ItemsString['StatusCode'].asInteger;
+               //uhmano -- final
+
              Except
               On E : Exception Do
                Begin
@@ -9866,6 +9875,15 @@ Begin
               Else If Assigned(TDWServerEvents(ServerMethodsClass.Components[i]).Events.EventByName[Pooler].OnReplyEvent) Then
                TDWServerEvents(ServerMethodsClass.Components[i]).Events.EventByName[Pooler].OnReplyEvent(DWParams, vResult);
               JsonMode := TDWServerEvents(ServerMethodsClass.Components[i]).Events.EventByName[Pooler].JsonMode;
+
+              //uhmano -- inicio  ServerEvents
+              if DWParams.ItemsString['ContentType'] <> nil then
+                  ContentType := DWParams.ItemsString['ContentType'].asString;
+
+              if DWParams.ItemsString['StatusCode'] <> nil then
+                  ErrorCode := DWParams.ItemsString['StatusCode'].asInteger;
+              //uhmano -- final
+
              Except
               On E : Exception Do
                Begin
@@ -10771,6 +10789,20 @@ Var
     DWParams.RequestHeaders.Input.Assign(ARequestInfo.RawHeaders);
    tmp := '';
   End;
+
+          //uhmano
+          // remoteIP
+          JSONParam                 := TJSONParam.Create(DWParams.Encoding);
+          JSONParam.ObjectDirection := odIN;
+          JSONParam.ParamName       := 'RemoteIP';
+          {$IFDEF FPC}
+          JSONParam.DatabaseCharSet := vDatabaseCharSet;
+          {$ENDIF}
+          JSONParam.AsString        := ARequestInfo.RemoteIP;
+          DWParams.Add(JSONParam);
+		  //uhmano - final
+
+
  end;
  Procedure MyDecodeAndSetParams(ARequestInfo: TIdHTTPRequestInfo);
  Var

--- a/CORE/Source/uRESTDWServerContext.pas
+++ b/CORE/Source/uRESTDWServerContext.pas
@@ -104,6 +104,7 @@ Type
   Function    GetDisplayName             : String;       Override;
   Procedure   SetDisplayName(Const Value : String);      Override;
   Constructor Create        (aCollection : TCollection); Override;
+  Destructor  Destroy; Override;    //uhmano
  Published
   Property TypeObject      : TTypeObject      Read vTypeObject      Write vTypeObject;
   Property ObjectDirection : TObjectDirection Read vObjectDirection Write vObjectDirection;
@@ -778,6 +779,7 @@ Destructor TDWServerContext.Destroy;
 Begin
  vEventList.Free;
  vBaseHeader.Free;
+ vDescription.Free;		//uhmano
  Inherited;
 End;
 
@@ -959,6 +961,12 @@ end;
 Procedure TDWParamMethod.SetDescription(Strings : TStrings);    //uhmano
 Begin
  vDescription.Assign(Strings);
+End;
+
+Destructor TDWParamMethod.Destroy;		//uhmano
+Begin
+ vDescription.Free;
+ Inherited;
 End;
 
 { TDWContextRules }

--- a/CORE/Source/uRESTDWServerContext.pas
+++ b/CORE/Source/uRESTDWServerContext.pas
@@ -98,6 +98,8 @@ Type
   vDefaultValue,
   vParamName       : String;
   vEncoded         : Boolean;
+  vDescription     : TStrings;    //uhmano
+  Procedure SetDescription     (Strings  : TStrings);   //uhmano
  Public
   Function    GetDisplayName             : String;       Override;
   Procedure   SetDisplayName(Const Value : String);      Override;
@@ -110,6 +112,7 @@ Type
   Property ParamName       : String           Read GetDisplayName   Write SetDisplayName;
   Property Encoded         : Boolean          Read vEncoded         Write vEncoded;
   Property DefaultValue    : String           Read vDefaultValue    Write vDefaultValue;
+  Property Description     : TStrings         Read vDescription     Write SetDescription;    //uhmano
 End;
 
 Type
@@ -330,6 +333,8 @@ Type
   vServerContext,
   vRootContext         : String;
   vOnBeforeRenderer    : TObjectEvent;
+  vDescription         : TStrings;    //uhmano
+  Procedure SetDescription     (Strings  : TStrings);   //uhmano
   Procedure SetBaseHeader(Value : TStrings);
 //  Procedure AfterConstruction; override;
   Procedure SetOnBeforeRenderer(Value : TObjectEvent);
@@ -346,6 +351,7 @@ Type
   Property    BaseHeader          : TStrings       Read vBaseHeader          Write SetBaseHeader;
   Property    RootContext         : String         Read vRootContext         Write vRootContext;
   Property    OnBeforeRenderer    : TObjectEvent   Read vOnBeforeRenderer    Write SetOnBeforeRenderer;
+  Property    Description         : TStrings       Read vDescription         Write SetDescription;    //uhmano
 End;
 
 implementation
@@ -760,7 +766,13 @@ Begin
  vEventList := TDWContextList.Create(Self, TDWContext);
  vIgnoreInvalidParams := False;
  vBaseHeader := TStringList.Create;
+ vDescription         := TStringList.Create;		//uhmano
 End;
+
+Procedure TDWServerContext.SetDescription(Strings   : TStrings);
+begin
+ vDescription.Assign(Strings);
+end;
 
 Destructor TDWServerContext.Destroy;
 Begin
@@ -925,6 +937,7 @@ Begin
  vEncoded         := True;
  vDefaultValue    := '';
  vAlias           := '';
+ vDescription     := TStringList.Create;    //uhmano
 End;
 
 function TDWParamMethod.GetDisplayName: String;
@@ -942,6 +955,11 @@ begin
    Inherited;
   End;
 end;
+
+Procedure TDWParamMethod.SetDescription(Strings : TStrings);    //uhmano
+Begin
+ vDescription.Assign(Strings);
+End;
 
 { TDWContextRules }
 

--- a/CORE/Source/uRESTDWServerEvents.pas
+++ b/CORE/Source/uRESTDWServerEvents.pas
@@ -76,6 +76,8 @@ Type
   vDefaultValue,
   vParamName       : String;
   vEncoded         : Boolean;
+  vDescription     : TStrings;    //uhmano
+  Procedure SetDescription     (Strings  : TStrings);    //uhmano
  Public
   Function    GetDisplayName             : String;       Override;
   Procedure   SetDisplayName(Const Value : String);      Override;
@@ -89,6 +91,7 @@ Type
   Property Alias           : String           Read vAlias           Write vAlias;
   Property Encoded         : Boolean          Read vEncoded         Write vEncoded;
   Property DefaultValue    : String           Read vDefaultValue    Write vDefaultValue;
+  Property Description     : TStrings         Read vDescription     Write SetDescription;    //uhmano
 End;
 
 Type
@@ -197,6 +200,8 @@ Type
   vAccessTag,
   vServerContext       : String;
   vOnCreate            : TObjectEvent;
+  vDescription         : TStrings;    //uhmano
+  Procedure SetDescription     (Strings  : TStrings);   //uhmano
  Public
   Destructor  Destroy; Override;
   Constructor Create(AOwner : TComponent);Override; //Cria o Componente
@@ -208,6 +213,7 @@ Type
   Property    AccessTag           : String       Read vAccessTag           Write vAccessTag;
   Property    ContextName         : String       Read vServerContext       Write vServerContext;
   Property    OnCreate            : TObjectEvent Read vOnCreate            Write vOnCreate;
+  Property    Description         : TStrings     Read vDescription         Write SetDescription;    //uhmano
 End;
 
 Type
@@ -221,6 +227,8 @@ Type
   vRESTClientPooler : TRESTClientPooler;
   vOnBeforeSend     : TOnBeforeSend;
   vCripto           : TCripto;
+  vDescription      : TStrings;   //uhmano
+  Procedure SetDescription     (Strings  : TStrings);   // Ma
   Procedure GetOnlineEvents         (Value  : Boolean);
   Procedure SetEventList            (aValue : TDWEventList);
   Function  GetRESTClientPooler             : TRESTClientPooler;
@@ -248,6 +256,7 @@ Type
   Property    RESTClientPooler : TRESTClientPooler Read GetRESTClientPooler Write SetRESTClientPooler;
   Property    Events           : TDWEventList      Read vEventList          Write SetEventList;
   Property    OnBeforeSend     : TOnBeforeSend     Read vOnBeforeSend       Write vOnBeforeSend; // Add Evento por Ico Menezes
+  Property    Description      : TStrings          Read vDescription        Write SetDescription;    //uhmano
 End;
 
 implementation
@@ -654,12 +663,18 @@ Begin
  vIgnoreInvalidParams := False;
  If Assigned(vOnCreate) Then
   vOnCreate(Self);
+ vDescription          := TStringList.Create;   //uhmano
 End;
 
 Destructor TDWServerEvents.Destroy;
 Begin
  vEventList.Free;
  Inherited;
+End;
+
+Procedure TDWServerEvents.SetDescription(Strings : TStrings);    //uhmano
+Begin
+ vDescription.Assign(Strings);
 End;
 
 procedure TDWParamsMethods.ClearList;
@@ -760,6 +775,7 @@ Begin
  vEncoded         := True;
  vDefaultValue    := '';
  vAlias           := '';
+ vDescription     := TStringList.Create;    //uhmano
 End;
 
 Destructor TDWParamMethod.Destroy;
@@ -783,6 +799,11 @@ begin
   End;
 end;
 
+Procedure TDWParamMethod.SetDescription(Strings : TStrings);    //uhmano
+Begin
+ vDescription.Assign(Strings);
+End;
+
 { TDWClientEvents }
 
 constructor TDWClientEvents.Create(AOwner: TComponent);
@@ -792,6 +813,7 @@ begin
  vCripto        := TCripto.Create;
  vGetEvents     := False;
  vEditParamList := True;
+ vDescription   := TStringList.Create;		//uhmano
 end;
 
 procedure TDWClientEvents.CreateDWParams(EventName: String;
@@ -803,6 +825,7 @@ Var
  vFound     : Boolean;
 Begin
  vParamName := '';
+ vDescription          := TStringList.Create;   //uhmano
  If vEventList.EventByName[EventName] <> Nil Then
   Begin
 //   If (Not Assigned(DWParams)) or (dwParams = nil) Then
@@ -1197,6 +1220,11 @@ begin
   if vRESTClientPooler <> nil then
     vRESTClientPooler.FreeNotification(Self);
 end;
+
+Procedure TDWClientEvents.SetDescription(Strings : TStrings);    //uhmano
+Begin
+ vDescription.Assign(Strings);
+End;
 
 Initialization
  RegisterClass(TDWServerEvents);

--- a/CORE/Source/uRESTDWServerEvents.pas
+++ b/CORE/Source/uRESTDWServerEvents.pas
@@ -669,6 +669,7 @@ End;
 Destructor TDWServerEvents.Destroy;
 Begin
  vEventList.Free;
+ vDescription.Free;		//uhmano
  Inherited;
 End;
 
@@ -780,6 +781,7 @@ End;
 
 Destructor TDWParamMethod.Destroy;
 Begin
+ vDescription.Free;		//uhmano
  Inherited;
 End;
 
@@ -867,6 +869,7 @@ End;
 destructor TDWClientEvents.Destroy;
 begin
  vEventList.Free;
+ vDescription.Free;		//uhmano
  FreeAndNil(vCripto);
  Inherited;
 end;


### PR DESCRIPTION
Pessoas,
melhorias que podem ser interessantes.

// uRESTDWServerContext
- propriedades Description ausentes para TDWParamMethod e TDWServerContext

// uRESTDWServerEvents
- propriedades Description ausentes para TDWParamMethod, TDWServerEvents e TDWClientEvents

// uRESTDWBase : atualização das variáveis ContentType ou ErrorCode se tiver DWParams 'ContentType' ou 'StatusCode', vindos de ReplyRequest/ReplyEvent
- após um ReplyRequest ou ReplyEvent, tratamento se o Params tiver algum com nome 'ContentType' ou 'StatusCode': atualiza as variáveis locais ContentType ou ErrorCode, respectivamente.
objetivo: modificar no retorno para o client, o ContentType e StatusCode
Exemplo: de 'application/json' para 'text/html' e 200 para 500 (Erro interno), para informar que houve um erro no servidor.

- novo parâmetro nome 'RemoteIP' (gerado dinâmicamente) para passar para um ReplyRequest ou ReplyEvent qual o IP do client remoto.
